### PR TITLE
🐛 Fix: 날짜 출력 및 조회 수정

### DIFF
--- a/src/histories/service/histories.service.ts
+++ b/src/histories/service/histories.service.ts
@@ -106,9 +106,9 @@ export class HistoriesService {
                 const kstDate = new Date(
                   purchased.purchasedDate.getTime() + KST_OFFSET_MS
                 );
-                return `${kstDate.getFullYear()}-${String(
-                  kstDate.getMonth() + 1
-                ).padStart(2, "0")}-${String(kstDate.getDate()).padStart(2, "0")}`;
+                return `${kstDate.getUTCFullYear()}-${String(
+                  kstDate.getUTCMonth() + 1
+                ).padStart(2, "0")}-${String(kstDate.getUTCDate()).padStart(2, "0")}`;
               })()
               : ""
           };
@@ -139,9 +139,9 @@ export class HistoriesService {
               const kstDate = new Date(
                 purchased.purchasedDate.getTime() + KST_OFFSET_MS
               );
-              return `${kstDate.getFullYear()}-${String(
-                kstDate.getMonth() + 1
-              ).padStart(2, "0")}-${String(kstDate.getDate()).padStart(2, "0")}`;
+              return `${kstDate.getUTCFullYear()}-${String(
+                kstDate.getUTCMonth() + 1
+              ).padStart(2, "0")}-${String(kstDate.getUTCDate()).padStart(2, "0")}`;
             })()
             : ""
         };
@@ -187,9 +187,9 @@ export class HistoriesService {
       const utcDate = h.purchasedDate;
       const kstDate = new Date(utcDate.getTime() + KST_OFFSET_MS);
 
-      const date = `${kstDate.getFullYear()}-${String(
-        kstDate.getMonth() + 1,
-      ).padStart(2, "0")}-${String(kstDate.getDate()).padStart(2, "0")}`;
+      const date = `${kstDate.getUTCFullYear()}-${String(
+        kstDate.getUTCMonth() + 1,
+      ).padStart(2, "0")}-${String(kstDate.getUTCDate()).padStart(2, "0")}`;
 
       if (!itemsByDate[date]) {
         itemsByDate[date] = [];


### PR DESCRIPTION
## 📌 PR 요약 (하나 이상 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 💡 주요 변경사항

- 날짜 출력 및 조회를 DB에 맞춰 변경

## 🔍 관련 이슈

- #

---

## 🌿 브랜치 정보

- 병합 대상 브랜치: develop
- 현재 작업 브랜치: fix/hogak/review-date

---

## 🧪 테스트 방법

- ***

## ⚠️ 주의사항

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 구매 날짜 및 리뷰 이력이 한국 표준시(KST) 기준으로 정확하게 표시되도록 수정했습니다.
  * 월간 및 일별 달력 뷰의 시작/종료 경계가 KST에 맞게 조정되어 집계와 정렬이 올바르게 수행됩니다.
  * 구매일이 일(YYYY-MM-DD) 형식으로 일관되게 표시되며, 값이 없을 경우 안전하게 빈값으로 처리됩니다.
  * 날짜 기반 검증 및 집계 로직 전반이 KST 기준으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->