### PR TITLE
♻️ Refactor: OAuth 콜백 딥링크 전환 및 토큰 교환 엔드포인트 추가

### DIFF
--- a/src/auth/constants/redis-keys.constant.ts
+++ b/src/auth/constants/redis-keys.constant.ts
@@ -28,6 +28,7 @@ export const RedisKeys = {
   oauthState: (state: string) => `oauth:state:${state}`,
   oauthReauthState: (state: string) => `oauth:reauth:${state}`,
   oauthConnectState: (state: string) => `oauth:connect:${state}`,
+  oauthTokenCode: (code: string) => `oauth:token-code:${code}`,
 } as const;
 
 export const RedisTTL = {
@@ -39,4 +40,5 @@ export const RedisTTL = {
   PASSWORD_RATE_LIMIT: 60 * 30, // 비밀번호 검증 시도 제한 30분
   EMAIL_SEND_ATTEMPT: 60 * 30, // 이메일 전송 시도 기록 30분
   DELETE_ACCOUNT_VERIFIED: 60 * 5, // 계정 탈퇴 본인 확인 상태 5분
+  OAUTH_TOKEN_CODE: 30, // OAuth 토큰 교환 code 30초
 } as const;

--- a/src/auth/controller/auth.controller.ts
+++ b/src/auth/controller/auth.controller.ts
@@ -22,6 +22,7 @@ import {
   UserProfileResponseDto,
   UpdatePasswordResponseDto,
   RefreshResponseDto,
+  OAuthTokenResponseDto,
 } from "../dto/response/auth.response.dto";
 import { AuthService } from "../service/auth.service";
 import { container } from "../../container";
@@ -424,7 +425,8 @@ export class AuthController {
       provider,
     } = params;
 
-    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:3000";
+    const appScheme = process.env.APP_SCHEME || "donakawa";
+    const frontendUrl = `${appScheme}://`;
 
     try {
       // 계정 연동 처리 추가
@@ -486,11 +488,12 @@ export class AuthController {
 
       // 일반 로그인 플로우
       const { tokens, isNewUser } = await loginHandler(code, state);
+      const tokenCode = await this.authService.issueOAuthTokenCode(tokens);
 
       if (isNewUser) {
-        req.res!.redirect(`${frontendUrl}/social/goal`);
+        req.res!.redirect(`${frontendUrl}/social/goal?code=${tokenCode}`);
       } else {
-        req.res!.redirect(`${frontendUrl}/auth/callback?success=true`);
+        req.res!.redirect(`${frontendUrl}/auth/callback?code=${tokenCode}`);
       }
     } catch (error) {
       console.error(`${provider} Login Error:`, error);
@@ -499,6 +502,18 @@ export class AuthController {
       );
     }
   }
+  /**
+   * @summary OAuth 토큰 교환 API
+   */
+  @Get("/oauth/token")
+  @SuccessResponse("200", "토큰 교환 성공")
+  public async exchangeOAuthToken(
+    @Query() code: string,
+  ): Promise<ApiResponse<OAuthTokenResponseDto>> {
+    const tokens = await this.authService.exchangeOAuthTokenCode(code);
+    return success(new OAuthTokenResponseDto(tokens));
+  }
+
   /**
    * @summary 구글 계정 연동 API
    */

--- a/src/auth/controller/auth.controller.ts
+++ b/src/auth/controller/auth.controller.ts
@@ -509,7 +509,9 @@ export class AuthController {
   @SuccessResponse("200", "토큰 교환 성공")
   public async exchangeOAuthToken(
     @Query() code: string,
+    @Request() req: ExpressRequest,
   ): Promise<ApiResponse<OAuthTokenResponseDto>> {
+    req.res!.setHeader("Cache-Control", "no-store");
     const tokens = await this.authService.exchangeOAuthTokenCode(code);
     return success(new OAuthTokenResponseDto(tokens));
   }

--- a/src/auth/dto/response/auth.response.dto.ts
+++ b/src/auth/dto/response/auth.response.dto.ts
@@ -31,6 +31,15 @@ export class RefreshResponseDto {
   }
 }
 
+export class OAuthTokenResponseDto {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  constructor(tokens: { accessToken: string; refreshToken: string }) {
+    this.accessToken = tokens.accessToken;
+    this.refreshToken = tokens.refreshToken;
+  }
+}
+
 export class UpdateNicknameResponseDto {
   readonly id: string;
   readonly nickname: string;

--- a/src/auth/service/auth.service.ts
+++ b/src/auth/service/auth.service.ts
@@ -344,6 +344,26 @@ export class AuthService {
   }
 
   // 토큰 갱신
+  async issueOAuthTokenCode(tokens: { accessToken: string; refreshToken: string }): Promise<string> {
+    const code = randomBytes(32).toString("hex");
+    await redis.set(
+      RedisKeys.oauthTokenCode(code),
+      JSON.stringify(tokens),
+      { EX: RedisTTL.OAUTH_TOKEN_CODE },
+    );
+    return code;
+  }
+
+  async exchangeOAuthTokenCode(code: string): Promise<{ accessToken: string; refreshToken: string }> {
+    const key = RedisKeys.oauthTokenCode(code);
+    const value = await redis.get(key);
+    if (!value) {
+      throw new UnauthorizedException("A008", "유효하지 않거나 만료된 코드입니다.");
+    }
+    await redis.del(key);
+    return JSON.parse(value);
+  }
+
   async refreshAccessToken(
     refreshToken: string,
   ): Promise<{ accessToken: string }> {

--- a/src/auth/service/auth.service.ts
+++ b/src/auth/service/auth.service.ts
@@ -356,11 +356,10 @@ export class AuthService {
 
   async exchangeOAuthTokenCode(code: string): Promise<{ accessToken: string; refreshToken: string }> {
     const key = RedisKeys.oauthTokenCode(code);
-    const value = await redis.get(key);
+    const value = await redis.getDel(key);
     if (!value) {
       throw new UnauthorizedException("A008", "유효하지 않거나 만료된 코드입니다.");
     }
-    await redis.del(key);
     return JSON.parse(value);
   }
 


### PR DESCRIPTION
## 📌 PR 요약 (하나 이상 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 리팩토링

---

## 💡 주요 변경사항

- OAuth 콜백 리다이렉트를 웹 URL에서 앱 딥링크(donakawa://)로 전환
- OAuth 로그인 성공 시 토큰을 30초 1회용 code로 교환하는 방식 적용 (GET /auth/oauth/token)
- Redis에 oauth:token-code:{code} key 추가 (TTL 30초)
- OAuthTokenResponseDto 추가

## 🔍 관련 이슈

- #235 

---

## 🌿 브랜치 정보

- 병합 대상 브랜치: develop
- 현재 작업 브랜치: refactor/cochae/auth

---

## 🧪 테스트 방법

- GET /auth/google/login 또는 GET /auth/kakao/login 호출 후 소셜 로그인 진행
- 콜백 후 donakawa://auth/callback?code=xxx 딥링크로 리다이렉트되는지 확인
- 발급된 code로 GET /auth/oauth/token?code=xxx 호출 → { accessToken, refreshToken } 반환 확인
- 동일 code 재사용 시 에러 반환 확인 (1회용)
- 30초 후 code 만료 확인

## ⚠️ 주의사항

-. env에 APP_SCHEME=donakawa 추가 필요
- 프론트(iOS)에서 donakawa:// 딥링크 스킴 등록 필요
- 프론트팀과 실제 앱 환경에서 딥링크 플로우 테스트 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * OAuth 로그인 후 발급된 일회성 인증 코드를 토큰으로 교환하는 기능이 추가되었습니다.
  * `GET /oauth/token`로 `code`를 전달하면 `accessToken`과 `refreshToken`을 받을 수 있습니다.
* **변경 사항**
  * OAuth 완료 후 리다이렉트 시, 인증 코드(`code` 쿼리 파라미터)가 포함되도록 변경되었습니다.
  * 리다이렉트 URL은 앱 스킴 기반으로 구성됩니다.
* **보안/응답**
  * 토큰 교환 응답에는 캐시 방지(`Cache-Control: no-store`)가 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->