### PR TITLE
♻️ Refactor: 앱 전용 전환에 따라 CORS·쿠키 인증 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,6 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
-        "cookie-parser": "^1.4.7",
-        "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "google-auth-library": "^10.5.0",
@@ -43,8 +41,6 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
-        "@types/cookie-parser": "^1.4.10",
-        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.0.6",
@@ -3202,16 +3198,6 @@
       "integrity": "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==",
       "license": "MIT"
     },
-    "node_modules/@types/cookie-parser": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
-      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/express": "*"
-      }
-    },
     "node_modules/@types/cookies": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz",
@@ -3221,16 +3207,6 @@
         "@types/connect": "*",
         "@types/express": "*",
         "@types/keygrip": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -4267,41 +4243,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/cookie-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
-      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
-    "cookie-parser": "^1.4.7",
-    "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "google-auth-library": "^10.5.0",
@@ -54,8 +52,6 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
-    "@types/cookie-parser": "^1.4.10",
-    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.0.6",

--- a/src/auth/middleware/auth.middleware.ts
+++ b/src/auth/middleware/auth.middleware.ts
@@ -22,11 +22,9 @@ export async function expressAuthentication(
         throw new UnauthorizedException("A011", "지원하지 않는 인증 방식입니다.");
     }
 
-    const token =
-        request.cookies?.accessToken ||
-        (request.headers.authorization?.startsWith("Bearer ")
-            ? request.headers.authorization.substring(7)
-            : undefined);
+    const token = request.headers.authorization?.startsWith("Bearer ")
+        ? request.headers.authorization.substring(7)
+        : undefined;
     if (!token) {
         throw new UnauthorizedException("A004", "인증 토큰이 없습니다.");
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,6 @@ import { AppError } from "./errors/app.error.js";
 import swaggerUi from "swagger-ui-express";
 import fs from "node:fs";
 import path from "node:path";
-import cors from "cors";
-import cookieParser from "cookie-parser";
 
 import { RegisterRoutes } from "./tsoa/routes.js";
 import { ValidateError } from "tsoa";
@@ -33,16 +31,6 @@ async function bootstrap() {
   });
 
   app.use(express.json());
-  app.use(
-    cors({
-      origin: ["http://localhost:5173", process.env.FRONTEND_URL].filter(
-        (origin): origin is string => Boolean(origin),
-      ),
-      credentials: true,
-    }),
-  );
-
-  app.use(cookieParser());
   app.use(express.urlencoded({ extended: false }));
 
   const swaggerPath = path.join(__dirname, "../dist/swagger.json");


### PR DESCRIPTION
## 📌 PR 요약 (하나 이상 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 💡 주요 변경사항

- 웹 프론트엔드 서비스 중단에 따라 cors, cookie-parser 미들웨어 및 의존성 제거
- 인증 토큰은 Authorization Bearer 헤더만 사용하도록 정리


---

## 🌿 브랜치 정보

- 병합 대상 브랜치: develop
- 현재 작업 브랜치: refactor/cochae/auth


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 인증 토큰이 쿠키가 아닌 `Authorization: Bearer` 헤더를 통해서만 처리됩니다.
  * 애플리케이션의 쿠키 파싱 및 CORS 처리가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->